### PR TITLE
feat: add index to msg_event_attr.type

### DIFF
--- a/sql/V1_2__add_msg_event_attr_type_idx.sql
+++ b/sql/V1_2__add_msg_event_attr_type_idx.sql
@@ -1,0 +1,3 @@
+CREATE INDEX IF NOT EXISTS msg_event_attr_type_idx ON msg_event_attr (
+  TYPE
+);


### PR DESCRIPTION
i wanted to handle this separately from https://github.com/regen-network/indexer/pull/12 so that we can better evaluate the performance of certain SQL queries there. this just adds an index on `type` for the `msg_event_attr` table (good to have regardless of the approach we go for in #12)