### PR TITLE
feat: add tx hash to retirements table

### DIFF
--- a/index_retires.py
+++ b/index_retires.py
@@ -10,15 +10,27 @@ def _index_retires(pg_conn, _client, _chain_num):
             cur,
             "retirements",
         ):
-            (type, block_height, tx_idx, msg_idx, _, _, chain_num, timestamp) = event[0]
+            (
+                type,
+                block_height,
+                tx_idx,
+                msg_idx,
+                _,
+                _,
+                chain_num,
+                timestamp,
+                tx_hash,
+            ) = event[0]
             normalize = {}
             normalize["type"] = type
             normalize["block_height"] = block_height
             normalize["tx_idx"] = tx_idx
             normalize["msg_idx"] = msg_idx
             normalize["chain_num"] = chain_num
+            normalize["timestamp"] = timestamp
+            normalize["tx_hash"] = tx_hash
             for entry in event:
-                (_, _, _, _, key, value, _, _) = entry
+                (_, _, _, _, key, value, _, _, _) = entry
                 value = value.strip('"')
                 if "v1alpha1.EventRetire" in entry[0]:
                     if key == "amount":
@@ -50,10 +62,11 @@ def _index_retires(pg_conn, _client, _chain_num):
                     normalize["chain_num"],
                     normalize["tx_idx"],
                     normalize["msg_idx"],
-                    timestamp,
+                    normalize["timestamp"],
+                    normalize["tx_hash"],
                 )
                 _cur.execute(
-                    "INSERT INTO retirements (type, amount, batch_denom, jurisdiction, owner, reason, block_height, chain_num, tx_idx, msg_idx, timestamp) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)",
+                    "INSERT INTO retirements (type, amount, batch_denom, jurisdiction, owner, reason, block_height, chain_num, tx_idx, msg_idx, timestamp, tx_hash) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)",
                     retirement,
                 )
                 pg_conn.commit()

--- a/sql/V1_6__add_tx_hash.sql
+++ b/sql/V1_6__add_tx_hash.sql
@@ -1,0 +1,2 @@
+ALTER TABLE retirements
+ADD COLUMN IF NOT EXISTS tx_hash TEXT NOT NULL;

--- a/sql/run_all_migrations.sh
+++ b/sql/run_all_migrations.sh
@@ -8,3 +8,4 @@ psql -c "\i V1_1__fix_msg_attr.sql" $DATABASE_URL
 psql -c "\i V1_2__add_retirements_table.sql" $DATABASE_URL
 psql -c "\i V1_3__add_msg_event_attr_type_idx.sql" $DATABASE_URL
 psql -c "\i V1_4__retirements_owner_idx.sql" $DATABASE_URL
+psql -c "\i V1_6__add_tx_hash.sql" $DATABASE_URL

--- a/utils.py
+++ b/utils.py
@@ -119,7 +119,8 @@ def events_to_process(cur, index_table_name):
            mea.key,
            mea.value,
            mea.chain_num,
-           TRIM(BOTH '"' FROM (tx.data -> 'tx_response' -> 'timestamp')::text) AS timestamp
+           TRIM(BOTH '"' FROM (tx.data -> 'tx_response' -> 'timestamp')::text) AS timestamp,
+           encode(tx.hash, 'hex') as tx_hash
     FROM msg_event_attr AS mea
     NATURAL LEFT JOIN {index_table_name} AS e
     NATURAL LEFT JOIN tx


### PR DESCRIPTION
Closes: https://github.com/regen-network/regen-registry/issues/1753

This adds the tx hash to each row in the retirements table.
This is done in such a way where it can be re-used in the future.
I.e. we can include the tx hash in the [proposals PR](https://github.com/regen-network/indexer/pull/19) as well.