### PR TITLE
fix: use BTREE index and adjust all_ecocredit_txes function

### DIFF
--- a/sql/V1_9__all_ecocredit_txes.sql
+++ b/sql/V1_9__all_ecocredit_txes.sql
@@ -1,4 +1,6 @@
-CREATE INDEX IF NOT EXISTS tx_data_tx_response_code_idx ON tx USING GIN ((DATA -> 'tx_response' -> 'code'));
+DROP INDEX IF EXISTS tx_data_tx_response_code_idx;
+
+CREATE INDEX IF NOT EXISTS tx_data_tx_response_code_idx ON tx USING BTREE ((DATA -> 'tx_response' -> 'code'));
 
 CREATE INDEX IF NOT EXISTS msg_event_type_idx ON msg_event (
   TYPE
@@ -11,6 +13,7 @@ CREATE FUNCTION all_ecocredit_txes () RETURNS SETOF tx AS $$
     from tx
     natural join msg_event as me
     where
-      data ->'tx_response'->'code' @> '0'
+      data ->'tx_response'->'code' = '0'
       and me.type like 'regen.ecocredit.%'
+    order by tx.block_height desc
 $$ LANGUAGE SQL STABLE;


### PR DESCRIPTION
The ecocredit txes must be delivered to client side ordered by descending block height because our activity table shows the most recent activities first.
The initial implementation of the `all_ecocredit_txes` was incredibly inefficient when I added an order by block height clause.
After digging in to the problem I realized that I made use of the wrong type of index for the `tx_response.code` field in our  `tx.data` JSONB column.

The postgresql documentation about indexes and order by clearly states this but I missed it initially:
> Of the index types currently supported by PostgreSQL, only B-tree can produce sorted output — the other index types return matching rows in an unspecified, implementation-dependent order.

https://www.postgresql.org/docs/current/indexes-ordering.html

So as such, this PR switches relevant index from GIN to BTREE.
Additionally this PR makes an adjustment to the `all_ecocredit_txes` query, since BTREE indexes support different operator types than GIN indexes.
After making this change in production there is a big performance boost to the query.

You can test it by going here and running the query below:
- https://api.regen.network/indexer/v1/graphiql

```graphql
{
  allEcocreditTxes(first: 10) {
    nodes {
      blockHeight
      hash
    }
    pageInfo {
      endCursor
      hasNextPage
    }
  }
}
```

This scales really well too, i.e. running the same query but asking for all of the results as opposed to just finishes in just a couple more seconds:
```graphql
{
  allEcocreditTxes {
    nodes {
      blockHeight
      hash
    }
    pageInfo {
      endCursor
      hasNextPage
    }
  }
}
```