### PR TITLE
fix: run checks on pushes to any branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: test
 on:
   push:
     branches:
-      - main
+      - "**"
   pull_request:
     branches:
       - main


### PR DESCRIPTION
@ryanchristo i noticed in the current PR i'm working on that the checks did not get run for a new commit that i pushed. i copied a line of configuration from the workflow in regen-server. and i think this change could fix that. it says "run ci checks on pushes to *any* branch"