### PR TITLE
fix: `all_ecocredit_txes` to use msg.data->@type instead of msg_event.type

### DIFF
--- a/migrations/committed/000001.sql
+++ b/migrations/committed/000001.sql
@@ -1,0 +1,18 @@
+--! Previous: -
+--! Hash: sha1:5ad90bce5c5fb68d0a8f886b6c07fb280ccd2c42
+
+CREATE INDEX IF NOT EXISTS msg_data_type_idx ON msg USING BTREE ((DATA -> '@type'));
+
+DROP FUNCTION IF EXISTS all_ecocredit_txes;
+
+CREATE FUNCTION public.all_ecocredit_txes() RETURNS SETOF public.tx
+  LANGUAGE sql STABLE
+  AS $$
+    select tx.*
+    from tx
+    inner join msg using (chain_num, block_height, tx_idx)
+    where
+      tx.data ->'tx_response'->'code' = '0' and
+      msg.data->>'@type' like '/regen.ecocredit.%'
+    order by tx.block_height desc
+$$;


### PR DESCRIPTION
closes: #55

The `all_ecocredit_txes` pg function - that we rely on on the front-end to display the activity table: https://app.regen.network/stats/activity which is **msg-based** - was using a join on the `msg_event` table instead of the `msg` table.
For certain msgs, multiple events can be emitted (eg for `MsgBuyDirect`: `EventBuyDirect`, `EventRetire` and `EventTransfer` can be emitted). This is why we could see the same row multiple times in the Activity table.

I've deployed to the indexer staging heroku app and db, which is used on https://dev.app.regen.network/stats/activity and now works as expected.