### PR TITLE
fix: indexing orders retirement reason and tmp disable index proposals

### DIFF
--- a/index_orders.py
+++ b/index_orders.py
@@ -58,11 +58,11 @@ def _index_orders(pg_conn, _client, _chain_num):
             normalize["tx_hash"] = tx_hash
             normalize["buyer_address"] = data["buyer"]
 
-            _cur.execute(
+            cur.execute(
                 """SELECT TRIM(BOTH '"' FROM (tx.data -> 'tx' -> 'body' -> 'memo')::text) AS memo FROM tx WHERE block_height=%s AND chain_num=%s AND tx_idx=%s""",
                 (block_height, chain_num, tx_idx),
             )
-            (memo,) = _cur.fetchone()
+            (memo,) = cur.fetchone()
 
             for order in data["orders"]:
                 # If all credits have been purchased in the sell order, then it's pruned from state,
@@ -138,14 +138,13 @@ def _index_orders(pg_conn, _client, _chain_num):
                         %s,
                         %s
                     );""").strip("\n")
-                    with pg_conn.cursor() as _cur:
-                        _cur.execute(
-                            insert_text,
-                            row,
-                        )
-                        logger.debug(_cur.statusmessage)
-                        pg_conn.commit()
-                        logger.info("order inserted...")
+                    cur.execute(
+                        insert_text,
+                        row,
+                    )
+                    logger.debug(cur.statusmessage)
+                    pg_conn.commit()
+                    logger.info("order inserted...")
 
 
 def index_orders():

--- a/main.py
+++ b/main.py
@@ -37,6 +37,6 @@ if __name__ == "__main__":
     index_blocks()
     index_orders()
     index_retires()
-    index_proposals()
+    # index_proposals()
     index_class_issuers()
     index_votes()


### PR DESCRIPTION
- Fixing an issue encountered when deploying to prod:

```
2025-02-25T16:44:26.005974+00:00 app[indexer.1]: Traceback (most recent call last):
2025-02-25T16:44:26.005974+00:00 app[indexer.1]:   File "/home/indexer/utils.py", line 87, in run
2025-02-25T16:44:26.005975+00:00 app[indexer.1]:     self._target(self.pg_conn, self.client, chain_num)
2025-02-25T16:44:26.005976+00:00 app[indexer.1]:   File "/home/indexer/index_orders.py", line 95, in _index_orders
2025-02-25T16:44:26.005977+00:00 app[indexer.1]:     order["retirement_reason"],
2025-02-25T16:44:26.005985+00:00 app[indexer.1]: KeyError: 'retirement_reason'
2025-02-25T16:44:26.096300+00:00 app[indexer.1]: 2025-02-25 16:44:26,095 - utils - ERROR - target=<function _index_orders at 0x7f2a343791f0> pid=7 exc='retirement_reason'
```

This is because there was not always a dedicated `retirement_reason` field in https://buf.build/regen/regen-ledger/docs/main:regen.ecocredit.marketplace.v1#regen.ecocredit.marketplace.v1.MsgBuyDirect.Order and the retirement reason could be stored in the tx memo instead.

- Disabling group proposals indexing for now (related to https://regennetwork.atlassian.net/browse/APP-470 which hasn't been prioritized), it's not used by our marketplace app so fine for now